### PR TITLE
Prevent build errors on AOSP source tree

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -43,6 +43,9 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
 	android-support-v7-cardview \
 	play 
 
+# Create $(TARGET_OUT_SHARED_LIBRARIES) if not already exists,
+# hence prevent build errors.
+$(shell mkdir -p $(TARGET_OUT_SHARED_LIBRARIES))
 $(shell cp $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/libbypass.so $(TARGET_OUT_SHARED_LIBRARIES))
 
 LOCAL_JNI_SHARED_LIBRARIES := libs/$(TARGET_ARCH_ABI)/libbypass


### PR DESCRIPTION
On cases when libbypass.so is copied earlier than
$(TARGET_OUT_SHARED_LIBRARIES) creation,
the entire build fails because libbypass.so becomes the /system/lib itself.

So attempt to mkdir it earlier.

Signed-off-by: arter97 qkrwngud825@gmail.com
