### PR TITLE
libbypass: fix compilation for arm64

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,7 +4,6 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE	:= libbypass
 LOCAL_MODULE_TAGS := optional
-LOCAL_MULTILIB := 32
 
 LOCAL_SRC_FILES := \
 	android/bypass.cpp \


### PR DESCRIPTION
"LOCAL_MULTILIB := 32" is not needed

Signed-off-by: arter97 qkrwngud825@gmail.com
