### PR TITLE
Update GenerateRecoveryScript due to ORS errors

### DIFF
--- a/src/com/ota/updates/tasks/GenerateRecoveryScript.java
+++ b/src/com/ota/updates/tasks/GenerateRecoveryScript.java
@@ -30,107 +30,110 @@ import com.ota.updates.utils.Tools;
 
 public class GenerateRecoveryScript extends AsyncTask<Void, String, Boolean> implements Constants {
 
-	public final String TAG = this.getClass().getSimpleName();
+    private static String SCRIPT_FILE = "/cache/recovery/openrecoveryscript";
+    private static String NEW_LINE = "\n";
+    public final String TAG = this.getClass().getSimpleName();
+    private Context mContext;
+    private ProgressDialog mLoadingDialog;
+    private StringBuilder mScript = new StringBuilder();
+    private String mFilename;
+    ;
+    private String mScriptOutput;
 
-	private Context mContext;
-	private ProgressDialog mLoadingDialog;
-	private StringBuilder mScript = new StringBuilder();
-	private static String SCRIPT_FILE = "/cache/recovery/openrecoveryscript";
-	private static String NEW_LINE = "\n";   
-	private String mFilename;;
-	private String mScriptOutput;
+    public GenerateRecoveryScript(Context context) {
+        mContext = context;
+        mFilename = RomUpdate.getFilename(mContext) + ".zip";
+    }
 
-	public GenerateRecoveryScript(Context context) {
-		mContext = context;
-		mFilename = RomUpdate.getFilename(mContext) + ".zip";
-	}
+    protected void onPreExecute() {
+        // Show dialog
+        mLoadingDialog = new ProgressDialog(mContext);
+        mLoadingDialog.setCancelable(false);
+        mLoadingDialog.setIndeterminate(true);
+        mLoadingDialog.setMessage(mContext.getString(R.string.rebooting));
+        mLoadingDialog.show();
 
-	protected void onPreExecute() {
-		// Show dialog
-		mLoadingDialog = new ProgressDialog(mContext);
-		mLoadingDialog.setCancelable(false);
-		mLoadingDialog.setIndeterminate(true);
-		mLoadingDialog.setMessage(mContext.getString(R.string.rebooting));
-		mLoadingDialog.show();
+        if (Preferences.getWipeData(mContext)) {
+            mScript.append("wipe data" + NEW_LINE);
+        }
+        if (Preferences.getWipeCache(mContext)) {
+            mScript.append("wipe cache" + NEW_LINE);
+        }
+        if (Preferences.getWipeDalvik(mContext)) {
+            mScript.append("wipe dalvik" + NEW_LINE);
+        }
 
-		if (Preferences.getWipeData(mContext)) {
-			mScript.append("wipe data" + NEW_LINE);
-		}
-		if (Preferences.getWipeCache(mContext)) {
-			mScript.append("wipe cache" + NEW_LINE);
-		}
-		if (Preferences.getWipeDalvik(mContext)) {
-			mScript.append("wipe dalvik" + NEW_LINE);
-		}
+        mScript.append("install /sdcard"
+                + File.separator
+                + OTA_DOWNLOAD_DIR
+                + File.separator
+                + mFilename
+                + NEW_LINE);
 
-		mScript.append("install " + "/sdcard" 
-				+ File.separator 
-				+ OTA_DOWNLOAD_DIR 
-				+ File.separator 
-				+ mFilename 
-				+ NEW_LINE);
+        File installAfterFlashDir = new File("/sdcard"
+                + File.separator
+                + OTA_DOWNLOAD_DIR
+                + File.separator
+                + INSTALL_AFTER_FLASH_DIR);
+        File[] filesArr = installAfterFlashDir.listFiles();
+        if (filesArr != null && filesArr.length > 0) {
+            for (int i = 0; i < filesArr.length; i++) {
+                mScript.append(NEW_LINE
+                        + "install /sdcard"
+                        + File.separator
+                        + OTA_DOWNLOAD_DIR
+                        + File.separator
+                        + INSTALL_AFTER_FLASH_DIR
+                        + File.separator
+                        + filesArr[i].getName());
+                if (DEBUGGING)
+                    Log.d(TAG, "install "
+                            + "/sdcard"
+                            + File.separator
+                            + OTA_DOWNLOAD_DIR
+                            + File.separator
+                            + INSTALL_AFTER_FLASH_DIR
+                            + File.separator
+                            + filesArr[i].getName());
+            }
+        }
 
-		File installAfterFlashDir = new File("/sdcard"
-				+ File.separator 
-				+ OTA_DOWNLOAD_DIR 
-				+ File.separator 
-				+ INSTALL_AFTER_FLASH_DIR);
-		File[] filesArr = installAfterFlashDir.listFiles();
-		if(filesArr != null && filesArr.length > 0) {
-			for(int i = 0; i < filesArr.length; i++) {
-				mScript.append("install " 
-						+ "/sdcard" 
-						+ OTA_DOWNLOAD_DIR 
-						+ File.separator 
-						+ INSTALL_AFTER_FLASH_DIR 
-						+ File.separator 
-						+ filesArr[i].getName());
-				if(DEBUGGING)
-					Log.d(TAG, "install " 
-							+ "/sdcard/" 
-							+ OTA_DOWNLOAD_DIR 
-							+ File.separator 
-							+ INSTALL_AFTER_FLASH_DIR 
-							+ File.separator 
-							+ filesArr[i].getName());
-			}
-		}
+        if (Preferences.getDeleteAfterInstall(mContext)) {
+            mScript.append(NEW_LINE
+                    + "cmd rm -rf "
+                    + "/sdcard"
+                    + File.separator
+                    + OTA_DOWNLOAD_DIR
+                    + File.separator
+                    + mFilename
+                    + NEW_LINE);
+        }
 
-		if (Preferences.getDeleteAfterInstall(mContext)) {
-			mScript.append("cmd rm -rf " 
-					+ "/sdcard/" 
-					+ OTA_DOWNLOAD_DIR 
-					+ File.separator 
-					+ INSTALL_AFTER_FLASH_DIR 
-					+ File.separator 
-					+ mFilename 
-					+ NEW_LINE);
-		}
+        mScriptOutput = mScript.toString();
+    }
 
-		mScriptOutput = mScript.toString();
-	}
+    @Override
+    protected Boolean doInBackground(Void... params) {
+        // Try create a dir in the cache folder
+        // Without root
+        String check = Tools.shell("mkdir -p /cache/recovery/; echo $?", false);
 
-	@Override
-	protected Boolean doInBackground(Void... params) {
-		// Try create a dir in the cache folder
-		// Without root
-		String check = Tools.shell("mkdir -p /cache/recovery/; echo $?", false);
+        // If not 0, then permission was denied
+        if (!check.equals("0")) {
+            // Run as root
+            Tools.shell("mkdir -p /cache/recovery/; echo $?", true);
+            Tools.shell("echo \"" + mScriptOutput + "\" > " + SCRIPT_FILE + "\n", true);
+        } else {
+            // Permission was enabled, run without root
+            Tools.shell("echo \"" + mScriptOutput + "\" > " + SCRIPT_FILE + "\n", false);
+        }
 
-		// If not 0, then permission was denied
-		if(!check.equals("0")) {
-			// Run as root
-			Tools.shell("mkdir -p /cache/recovery/; echo $?", true);
-			Tools.shell("echo \"" + mScriptOutput + "\" > " + SCRIPT_FILE + "\n", true);
-		} else {
-			// Permission was enabled, run without root
-			Tools.shell("echo \"" + mScriptOutput + "\" > " + SCRIPT_FILE + "\n", false);
-		}
+        return true;
+    }
 
-		return true;
-	}
-	@Override
-	protected void onPostExecute(Boolean value) {
-		mLoadingDialog.cancel();
-		Tools.recovery(mContext);
-	}
+    @Override
+    protected void onPostExecute(Boolean value) {
+        mLoadingDialog.cancel();
+        Tools.recovery(mContext);
+    }
 }


### PR DESCRIPTION
I forked and reset my GenerateRecoveryScript to the one previous to this temp fork branch (OTA Updates 2.4.5) placed back into my file caused some problems where the append function was appending and concatenating at the end of existing lines (e.g. install /sdcard/OTAUpdates/InstallAfterFlash/supersu.zipcmd rm-rf /sdcard/OTAUpdates/update.zip) and this raises an error in TWRP 2.8.7.0.

I fixed these issues by calling upon NEW_LINE upon every append call after the initial append call (line 66). This allows for the script to have new lines after each append, just in case the strings get concatenated under certain circumstances.

Current implementation would bug out when you try to Delete file after flash or try to install multiple InstallAfterFlash zips.
